### PR TITLE
Disable debugging settings

### DIFF
--- a/src/denspart/vh.py
+++ b/src/denspart/vh.py
@@ -145,21 +145,20 @@ def optimize_pro_model(
                 "Please report this issue on https://github.com/theochem/denspart/issues"
             )
 
-    with np.errstate(all="raise"):
-        # The errstate is changed to detect potentially nasty numerical issues.
-        # Optimize parameters within the bounds.
-        bounds = np.concatenate([fn.bounds for fn in pro_model.fns])
+    # The errstate is changed to detect potentially nasty numerical issues.
+    # Optimize parameters within the bounds.
+    bounds = np.concatenate([fn.bounds for fn in pro_model.fns])
 
-        optresult = minimize(
-            cost_grad,
-            pars0,
-            method="trust-constr",
-            jac=True,
-            hess=SR1(),
-            bounds=Bounds(bounds[:, 0], bounds[:, 1], keep_feasible=True),
-            callback=callback,
-            options={"gtol": gtol, "maxiter": maxiter},
-        )
+    optresult = minimize(
+        cost_grad,
+        pars0,
+        method="trust-constr",
+        jac=True,
+        hess=SR1(),
+        bounds=Bounds(bounds[:, 0], bounds[:, 1], keep_feasible=True),
+        callback=callback,
+        options={"gtol": gtol, "maxiter": maxiter},
+    )
 
     print("-----  -----  -----------  -----------  -----------  -----------  -----------")
     # Check for convergence.


### PR DESCRIPTION
Fixes #28 

@lucienwb Can you try this change? When I run the partitioning with your example as follows, it converges quite quickly:

```bash
denspart density.npz mbis.npz -c0
```

The `-c0` option disables localized integration grids. It is a bit more expensive but it should not matter for small molecules. The localized grids are an approximation, and they may introduce small errors in the gradient of the KLD, which may confuse the optimizer.